### PR TITLE
Add parseraw function

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -13,6 +13,19 @@ import (
 //
 // MetricsQL is backwards-compatible with PromQL.
 func Parse(s string) (Expr, error) {
+	e, err := ParseRaw(s)
+	if err != nil {
+		return nil, err
+	}
+	e = removeParensExpr(e)
+	e = simplifyConstants(e)
+	if err := checkSupportedFunctions(e); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+func ParseRaw(s string) (Expr, error) {
 	// Parse s
 	e, err := parseInternal(s)
 	if err != nil {
@@ -23,11 +36,6 @@ func Parse(s string) (Expr, error) {
 	was := getDefaultWithArgExprs()
 	if e, err = expandWithExpr(was, e); err != nil {
 		return nil, fmt.Errorf(`cannot expand WITH expressions: %s`, err)
-	}
-	e = removeParensExpr(e)
-	e = simplifyConstants(e)
-	if err := checkSupportedFunctions(e); err != nil {
-		return nil, err
 	}
 	return e, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 )
 
-func TestParseSuccess(t *testing.T) {
+func helpers(t *testing.T, parser func(string) (Expr, error)) (func(string, string), func(string)) {
 	another := func(s string, sExpected string) {
 		t.Helper()
 
-		e, err := Parse(s)
+		e, err := parser(s)
 		if err != nil {
 			t.Fatalf("unexpected error when parsing %s: %s", s, err)
 		}
@@ -17,10 +17,16 @@ func TestParseSuccess(t *testing.T) {
 			t.Fatalf("unexpected string constructed;\ngot\n%s\nwant\n%s", res, sExpected)
 		}
 	}
+
 	same := func(s string) {
 		t.Helper()
 		another(s, s)
 	}
+	return another, same
+}
+
+func TestParseSuccess(t *testing.T) {
+	another, same := helpers(t, Parse)
 
 	// metricExpr
 	same(`{}`)
@@ -951,4 +957,11 @@ func TestParseError(t *testing.T) {
 	f(`with (x={a="b" or c="d"}) x{d="e" or z="c"}`)
 	f(`with (x={a="b" or c="d"}) {x,d="e"}`)
 	f(`with (x={a="b" or c="d"}) {x,d="e" or z="c"}`)
+}
+
+func TestParseRawSuccess(t *testing.T) {
+	another, same := helpers(t, ParseRaw)
+
+	same("(metric[5m])")
+	another(`100 / 100`, `(100 / 100)`)
 }


### PR DESCRIPTION
We at Lyft are using this library to lint and perform operations on the AST of metricsql queries. This means we are roundtripping the queries from a source and back. For our usecase, we'd prefer to have a way to operate directly on the unoptimized parse tree. As an example, there are times where doing constant folding would write back a query that is less useful to a human.

To enable this use case, I've pulled out the core functionality of calling parseInternal, and evaluating the WITH expressions into a separate function.